### PR TITLE
Fix cron 502s: refresh-token no-op + proxy status pass-through

### DIFF
--- a/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Playlist/SpotifyTokenService.java
+++ b/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Playlist/SpotifyTokenService.java
@@ -66,10 +66,15 @@ public class SpotifyTokenService {
 
     public boolean refreshSpotifyTokenPeriodically(){
         SpotifyToken currentToken = getSpotifyToken();
-        if(currentToken != null && tokenIsExpired(currentToken)){
+        if(currentToken == null){
+            log.warn("No Spotify token stored; an admin must authorize once via /playlists/auth.");
+            return false;
+        }
+        if(tokenIsExpired(currentToken)){
             return refreshTokenWithRetries(3);
         }
-        return false; 
+        // Token is still valid — nothing to refresh. For the scheduled job this is success, not failure.
+        return true;
     }
 
     private boolean refreshTokenWithRetries(int retryCount) {

--- a/Frontend/api/purgeDB.js
+++ b/Frontend/api/purgeDB.js
@@ -27,11 +27,19 @@ export default async function purgeDB(req, res) {
     });
     return res.status(200).json(response.data);
   } catch (error) {
+    const backendStatus = error.response?.status;
     console.error(
       "purgeDB: backend purge failed:",
-      error.response?.status,
+      backendStatus,
       error.message
     );
-    return res.status(502).json({ error: "Failed to purge setlists DB" });
+    // Surface the backend's real status (e.g. 401 admin-auth failure) so it's
+    // visible directly in the cron log instead of being masked as a blanket 502.
+    if (backendStatus) {
+      return res
+        .status(backendStatus)
+        .json({ error: "Backend rejected purge", backendStatus });
+    }
+    return res.status(502).json({ error: "Could not reach backend" });
   }
 }

--- a/Frontend/api/refreshSpotifyToken.js
+++ b/Frontend/api/refreshSpotifyToken.js
@@ -29,11 +29,19 @@ export default async function refreshSpotifyToken(req, res) {
     });
     return res.status(200).json(response.data);
   } catch (error) {
+    const backendStatus = error.response?.status;
     console.error(
       "refreshSpotifyToken: backend refresh failed:",
-      error.response?.status,
+      backendStatus,
       error.message
     );
-    return res.status(502).json({ error: "Failed to refresh Spotify token" });
+    // Surface the backend's real status (e.g. 401 admin-auth failure) so it's
+    // visible directly in the cron log instead of being masked as a blanket 502.
+    if (backendStatus) {
+      return res
+        .status(backendStatus)
+        .json({ error: "Backend rejected refresh", backendStatus });
+    }
+    return res.status(502).json({ error: "Could not reach backend" });
   }
 }


### PR DESCRIPTION
Fixes the daily Vercel cron jobs returning 502.

## 1. Backend: refresh-token no longer 500s on a no-op
`refreshSpotifyTokenPeriodically()` returned `false` whenever the Spotify token wasn't expired, and the controller maps `false` to HTTP 500, so any time the token was still valid (the normal case, e.g. right after a manual authorization) the endpoint 500'd and the proxy surfaced it as 502.

A still-valid token is now treated as success (200). It only returns `false` (and so 500) when there is no token at all or an actual refresh attempt fails.

## 2. Frontend: proxies surface the backend's real status
`api/refreshSpotifyToken.js` and `api/purgeDB.js` previously returned a blanket 502 for any backend error, hiding whether it was an auth failure or something else. They now pass through the backend's actual status (e.g. a 401 admin-auth failure shows as 401 in the cron log), falling back to 502 only when the backend is unreachable. Makes future cron failures self-diagnosing.

Verified: `./gradlew compileJava`.
