### PR TITLE
Live typeahead artist search

### DIFF
--- a/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Artist/ArtistController.java
+++ b/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Artist/ArtistController.java
@@ -38,4 +38,11 @@ public class ArtistController {
                 .map(result -> new ResponseEntity<>(result, HttpStatus.OK))
                 .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }
+
+    // Typeahead suggestions: returns a ranked list of matching artists (200 with a
+    // possibly-empty list, so the frontend can show an inline "no matches" state).
+    @GetMapping("/suggest")
+    public ResponseEntity<List<Artist>> suggestArtists(@RequestParam String artistName) {
+        return ResponseEntity.ok(artistService.suggestArtists(artistName));
+    }
 }

--- a/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Artist/ArtistService.java
+++ b/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Artist/ArtistService.java
@@ -3,6 +3,7 @@ package com.frozenleafstudio.dev.AutomatedSetlist.Artist;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -91,6 +92,52 @@ public void saveArtist(Artist newArtist) {
     public Optional<Artist> searchArtistOnSetlist(String artistName) {
         return singleArtist(artistName)
             .or(() -> fetchArtistsFromApi(artistName, false));
+    }
+
+    // Typeahead: return a ranked list of matching artists (not just the top hit).
+    // Results from setlist.fm are kept in their relevance order, but any result
+    // whose name doesn't contain the typed text is demoted to the bottom so an
+    // off-target top hit (e.g. searching "homer" surfacing an unrelated artist)
+    // can't dominate. No DB writes here — that happens when an artist is chosen.
+    public List<Artist> suggestArtists(String artistName) {
+        if (artistName == null || artistName.trim().length() < 2) {
+            return Collections.emptyList();
+        }
+        String query = artistName.trim();
+        String encodedArtistName = encodeArtistName(query);
+        if (encodedArtistName.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String url = setlistApiUrl + "/search/artists?artistName=" + encodedArtistName + "&p=1&sort=relevance";
+        try {
+            URI uri = new URI(url);
+            ResponseEntity<ArtistSearchResponse> response = restTemplate.exchange(
+                    uri, HttpMethod.GET, new HttpEntity<>(createHeaders()), ArtistSearchResponse.class);
+            List<ArtistSearchResult> artistList = response.getBody() != null && response.getBody().getArtist() != null
+                    ? response.getBody().getArtist() : Collections.emptyList();
+
+            String lowerQuery = query.toLowerCase();
+            return artistList.stream()
+                    .map(this::mapApiResultToArtistEntity)
+                    .sorted(Comparator.comparingInt(a -> nameContainsQuery(a.getName(), lowerQuery) ? 0 : 1))
+                    .limit(8)
+                    .collect(Collectors.toList());
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+                log.info("No artist suggestions found for: {}", query);
+            } else {
+                log.error("Error fetching artist suggestions for: {}", query, e);
+            }
+            return Collections.emptyList();
+        } catch (Exception e) {
+            log.error("Error fetching artist suggestions for: {}", query, e);
+            return Collections.emptyList();
+        }
+    }
+
+    private boolean nameContainsQuery(String name, String lowerQuery) {
+        return name != null && name.toLowerCase().contains(lowerQuery);
     }
     
     // Fetch artist details from the external API

--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef } from "react";
-import { searchArtists } from "./services/ArtistService";
 import { Artist } from "./models/Artist";
 import { Setlist } from "./models/Setlist";
 import { searchSetlists } from "./services/SetlistService";
@@ -24,35 +23,24 @@ function App() {
   const [isPlaylistLoading, setIsPlaylistLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState<number>(1);
 
-  const handleSearchSubmit = async (searchTerm: string) => {
-    const artistData = await searchArtists(searchTerm);
-
-    if (!artistData || !artistData.name || !artistData.mbid) {
-      console.error("Artist not found or invalid data");
-      setArtist(null);
-      setSetlists(null);
-      setSetlistsExist(true);
-      return;
-    }
-
-    const newArtist = new Artist(artistData);
+  const handleArtistSelect = async (selectedArtist: Artist) => {
     setSearchSubmitted(true);
 
-    if (newArtist.name !== prevArtistRef.current?.name) {
+    if (selectedArtist.name !== prevArtistRef.current?.name) {
       resetStates();
     }
 
-    setArtist(newArtist);
-    prevArtistRef.current = newArtist;
-    const setlistData = await searchSetlists(newArtist.mbid, 1);
+    setArtist(selectedArtist);
+    prevArtistRef.current = selectedArtist;
 
-    if (setlistData && setlistData.length > 0) {
-      setSetlists(setlistData);
-      setSetlistsExist(true);
-    } else {
+    try {
+      const setlistData = await searchSetlists(selectedArtist.mbid, 1);
+      setSetlists(setlistData && setlistData.length > 0 ? setlistData : []);
+    } catch (error) {
+      console.error("Error fetching setlists: ", error);
       setSetlists([]);
-      setSetlistsExist(true);
     }
+    setSetlistsExist(true);
   };
   const fetchMoreSetlists = async () => {
     if (artist && artist.mbid && setlists) {
@@ -125,7 +113,7 @@ function App() {
             searchSubmitted ? "search-submitted" : ""
           }`}
         >
-          <SearchBar onSearchSubmit={handleSearchSubmit} />
+          <SearchBar onArtistSelect={handleArtistSelect} />
           {setlistsExist && (
             <div className="main-content">
               <ArtistSearchResults artistSearch={artist} />

--- a/Frontend/src/features/artist/SearchBar.css
+++ b/Frontend/src/features/artist/SearchBar.css
@@ -1,7 +1,12 @@
-.search-bar-container {
-  display: flex;
+.search-bar-container-wrapper {
+  position: relative;
   min-width: 500px;
   width: 40vw;
+}
+.search-bar-container {
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
   align-items: center;
   background-color: #363457;
   border-radius: 40px;
@@ -57,4 +62,71 @@
 .search-input:focus {
   outline: none;
   box-shadow: 0 0 0 2px #00a693;
+}
+
+.clear-button {
+  all: unset;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: #c0c0c0;
+  font-size: 1.4rem;
+  margin-left: 8px;
+}
+.clear-button:hover {
+  color: #00a693;
+}
+
+/* Typeahead suggestions dropdown */
+.search-suggestions {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 6px;
+  list-style: none;
+  background-color: #363457;
+  border-radius: 10px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+  max-height: 360px;
+  overflow-y: auto;
+  z-index: 20;
+  text-align: left;
+}
+
+.suggestion-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  color: #ffffff;
+}
+.suggestion-item.active {
+  background-color: #735290;
+}
+
+.suggestion-icon {
+  color: #c0c0c0;
+  font-size: 1.2rem;
+  flex: 0 0 auto;
+}
+.suggestion-name {
+  font-weight: 600;
+}
+.suggestion-disambiguation {
+  color: #c0c0c0;
+  font-size: 0.85rem;
+  margin-left: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.suggestion-status {
+  padding: 12px 14px;
+  color: #c0c0c0;
+  font-style: italic;
 }

--- a/Frontend/src/features/artist/SearchBar.tsx
+++ b/Frontend/src/features/artist/SearchBar.tsx
@@ -1,45 +1,199 @@
-import React, { useState } from "react";
-import { MdSearch } from "react-icons/md";
+import React, { useState, useEffect, useRef } from "react";
+import { MdSearch, MdClose } from "react-icons/md";
+import { Artist } from "../../models/Artist";
+import { suggestArtists } from "../../services/ArtistService";
 import "./SearchBar.css";
-import "react-datepicker/dist/react-datepicker.css";
 
 type SearchBarProps = {
-  onSearchSubmit: (searchTerm: string) => void; //prop to handle search action
+  onArtistSelect: (artist: Artist) => void; // fired when the user picks an artist
 };
-const SearchBar: React.FC<SearchBarProps> = ({ onSearchSubmit }) => {
+
+const DEBOUNCE_MS = 280;
+const MIN_CHARS = 2;
+
+const capitalize = (str: string) =>
+  str
+    ? str
+        .split(" ")
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+        .join(" ")
+    : "";
+
+const SearchBar: React.FC<SearchBarProps> = ({ onArtistSelect }) => {
   const [input, setInput] = useState("");
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault(); // Prevent the default form submit action
-    onSearchSubmit(input);
+  const [results, setResults] = useState<Artist[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [hasQueried, setHasQueried] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const skipFetchRef = useRef(false); // suppress the fetch triggered by selecting
+
+  // Debounced suggestion fetch, cancelling any in-flight request as the user types.
+  useEffect(() => {
+    if (skipFetchRef.current) {
+      skipFetchRef.current = false;
+      return;
+    }
+
+    const query = input.trim();
+    if (query.length < MIN_CHARS) {
+      abortRef.current?.abort();
+      setResults([]);
+      setOpen(false);
+      setHasQueried(false);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const handle = setTimeout(async () => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      try {
+        const data = await suggestArtists(query, controller.signal);
+        const artists = data.map((a) => new Artist(a));
+        setResults(artists);
+        setActiveIndex(-1);
+        setHasQueried(true);
+        setOpen(true);
+      } catch (err) {
+        const e = err as { code?: string; name?: string };
+        if (e?.code === "ERR_CANCELED" || e?.name === "CanceledError") return;
+        console.error("Error fetching artist suggestions: ", err);
+        setResults([]);
+        setHasQueried(true);
+        setOpen(true);
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+  }, [input]);
+
+  // Close the dropdown when clicking outside the search bar.
+  useEffect(() => {
+    const onClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, []);
+
+  const select = (artist: Artist) => {
+    abortRef.current?.abort();
+    skipFetchRef.current = true;
+    setInput(capitalize(artist.name));
+    setResults([]);
+    setOpen(false);
+    setActiveIndex(-1);
+    onArtistSelect(artist);
+  };
+
+  const clear = () => {
+    abortRef.current?.abort();
+    setInput("");
+    setResults([]);
+    setOpen(false);
+    setHasQueried(false);
+    setActiveIndex(-1);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!open && results.length) setOpen(true);
+      setActiveIndex((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (results.length === 0) return;
+      select(results[activeIndex >= 0 ? activeIndex : 0]);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
   };
 
   return (
-    <form className="search-bar-container" onSubmit={handleSubmit}>
-      <MdSearch id="search-icon" />
-      <input
-        className="search-input"
-        placeholder="Type Artist name to search setlists..."
-        type="text"
-        value={input}
-        onChange={(e) => setInput(e.target.value)}
-        onKeyPress={(e) => e.key === "Enter" && handleSubmit}
-      />
-      <button type="submit" className="search-button">
-        Search
-      </button>
-    </form>
+    <div className="search-bar-container-wrapper" ref={containerRef}>
+      <div className="search-bar-container">
+        <MdSearch id="search-icon" />
+        <input
+          className="search-input"
+          type="text"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls="artist-suggestions"
+          aria-autocomplete="list"
+          aria-activedescendant={
+            activeIndex >= 0 ? `artist-option-${activeIndex}` : undefined
+          }
+          autoComplete="off"
+          placeholder="Type an artist name to search setlists..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={() => {
+            if (results.length) setOpen(true);
+          }}
+        />
+        {input && (
+          <button
+            type="button"
+            className="clear-button"
+            onClick={clear}
+            aria-label="Clear search"
+          >
+            <MdClose />
+          </button>
+        )}
+      </div>
+
+      {open && (
+        <ul
+          className="search-suggestions"
+          id="artist-suggestions"
+          role="listbox"
+        >
+          {loading && <li className="suggestion-status">Searching…</li>}
+          {!loading && hasQueried && results.length === 0 && (
+            <li className="suggestion-status">No artists found</li>
+          )}
+          {!loading &&
+            results.map((artist, i) => (
+              <li
+                key={artist.mbid || `${artist.name}-${i}`}
+                id={`artist-option-${i}`}
+                role="option"
+                aria-selected={i === activeIndex}
+                className={`suggestion-item ${i === activeIndex ? "active" : ""}`}
+                onMouseEnter={() => setActiveIndex(i)}
+                onMouseDown={(e) => {
+                  e.preventDefault(); // keep input focus through the click
+                  select(artist);
+                }}
+              >
+                <MdSearch className="suggestion-icon" />
+                <span className="suggestion-name">{capitalize(artist.name)}</span>
+                {artist.disambiguation && (
+                  <span className="suggestion-disambiguation">
+                    {artist.disambiguation}
+                  </span>
+                )}
+              </li>
+            ))}
+        </ul>
+      )}
+    </div>
   );
 };
-export default SearchBar;
 
-/*   
-      button and datepicker to be used future phases (after MVP)
-      icon = MdCalendarMonth
-      import DatePicker from "react-datepicker";
-      const selectedDate = (date: Date) => {setDate(date);};
-      const [date, setDate] = useState(new Date());
-      const [isOpen, setIsOpen] = useState(false);
-      <button id="btn-no-style" onClick={() => setIsOpen(!isOpen)}>
-        <MdCalendarMonth id="calendar-icon" />
-      </button>
-      {isOpen ? <DatePicker selected={date} onChange={selectedDate} /> : null} */
+export default SearchBar;

--- a/Frontend/src/services/ArtistService.tsx
+++ b/Frontend/src/services/ArtistService.tsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { Artist } from "../models/Artist";
 
 const BASE_URL = "https://api.frozenleafstudio.com/api/v1/artists";
 //const BASE_URL = "http://localhost:8080/api/v1/artists";
@@ -13,4 +14,18 @@ export const searchArtists = async (searchTerm: string) => {
     console.error("Error searching artists: ", error);
     return null;
   }
+};
+
+// Typeahead suggestions. Pass an AbortSignal so stale in-flight requests can be
+// cancelled when the user keeps typing. Throws on real errors (incl. cancellation,
+// which the caller is expected to ignore).
+export const suggestArtists = async (
+  artistName: string,
+  signal?: AbortSignal
+): Promise<Artist[]> => {
+  const response = await axios.get(`${BASE_URL}/suggest`, {
+    params: { artistName },
+    signal,
+  });
+  return response.data ?? [];
 };


### PR DESCRIPTION
Replaces the single-result artist search with a Spotify-style typeahead dropdown.

## Problem
Searching e.g. "homer" silently auto-selected setlist.fm's single top relevance hit, which for short/ambiguous queries could be an unrelated artist. The backend already fetched a ranked list but discarded all but the first.

## Backend
- New `GET /api/v1/artists/suggest?artistName=` returns the ranked list (capped at 8) instead of just the top hit.
- Results that don't contain the typed text are demoted so an off-target hit can't dominate; setlist.fm's relevance order is preserved within matches.
- Returns 200 with a possibly-empty list (so the UI can show an inline "no matches" state). No DB writes.

## Frontend
- Debounced suggestions (280ms, min 2 chars) with stale-request cancellation via AbortController.
- Keyboard nav (up/down/Enter/Esc), click-to-select, click-outside-to-close, loading and "No artists found" states.
- Shows each artist's disambiguation label so near-duplicates are distinguishable.
- Selecting an artist goes straight to its setlists (skips the redundant re-search).
- Dropdown styled with the existing palette only (#363457 surface, #735290 active, #c0c0c0 secondary, matching radius/shadow).
- Side effect: drops the unused react-datepicker CSS import (~22KB off the CSS bundle).

## Verified
`npm run build` passed, `npm run lint` (--max-warnings 0) passed, `./gradlew compileJava` passed.
