### PR TITLE
Responsive layout for modern phones

### DIFF
--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -1,5 +1,6 @@
 .App {
   min-height: 100vh;
+  min-height: 100dvh; /* modern phones: excludes dynamic browser chrome */
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -14,6 +15,7 @@
   align-items: center;
   min-width: 400px;
   max-height: 95vh;
+  max-height: 95dvh;
 }
 .main-container.search-submitted {
   padding-top: 15px;
@@ -83,7 +85,9 @@
 @media (max-width: 768px) {
   .main-container {
     width: 100%;
+    min-width: 0; /* clear the 400px desktop min so it can't overflow a phone */
     height: 100vh;
+    height: 100dvh;
     margin-top: 10px;
   }
 

--- a/Frontend/src/features/artist/Results.css
+++ b/Frontend/src/features/artist/Results.css
@@ -7,3 +7,9 @@
   z-index: 10;
   border-radius: 15px;
 }
+
+@media (max-width: 600px) {
+  .artist-name-container {
+    padding: 12px 16px;
+  }
+}

--- a/Frontend/src/features/artist/SearchBar.css
+++ b/Frontend/src/features/artist/SearchBar.css
@@ -1,7 +1,13 @@
 .search-bar-container-wrapper {
   position: relative;
-  min-width: 500px;
-  width: 40vw;
+  /* Mobile-first: fit the phone viewport. Desktop width is restored below. */
+  width: min(92vw, 600px);
+}
+@media (min-width: 768px) {
+  .search-bar-container-wrapper {
+    width: 40vw;
+    min-width: 500px;
+  }
 }
 .search-bar-container {
   display: flex;

--- a/Frontend/src/features/playlist/Modal.css
+++ b/Frontend/src/features/playlist/Modal.css
@@ -16,6 +16,7 @@
   padding: 20px;
   padding-bottom: 0;
   border-radius: 8px;
+  width: 90vw; /* keep margins from the screen edge on phones */
   max-width: 600px;
   max-height: 80%;
   display: flex;


### PR DESCRIPTION
A pass at making the app usable on phones from the last ~4 years (about 360-430px wide).

## Fixes
- **Search bar** was `min-width: 500px`, so it overflowed the viewport on *every* phone. Now mobile-first fluid (`min(92vw, 600px)`); the desktop `40vw`/`500px` sizing is restored at `>=768px`, so desktop is unchanged.
- **main-container** `min-width: 400px` is now cleared on small screens so it can't force horizontal overflow.
- **Heights** use `100dvh`/`95dvh` (with `vh` fallback) so full-height layout accounts for dynamic mobile browser chrome.
- **Modal** is `width: 90vw` (capped at 600px) so it keeps margins from the screen edge.
- Trimmed the artist-name header padding on small screens.

Desktop appearance is intentionally unchanged (all phone behavior is gated behind existing/new small-width rules).

## Verified
`npm run build` passed, `npm run lint` passed. **Not yet visually verified on a device**; worth a look in DevTools device mode (iPhone 12/14, Pixel 7) before merge.
