### PR TITLE
API base URL via VITE_API_BASE_URL (no more comment-flipping)

### DIFF
--- a/Frontend/src/services/ArtistService.tsx
+++ b/Frontend/src/services/ArtistService.tsx
@@ -1,8 +1,8 @@
 import axios from "axios";
 import { Artist } from "../models/Artist";
+import { API_ROOT } from "./apiConfig";
 
-const BASE_URL = "https://api.frozenleafstudio.com/api/v1/artists";
-//const BASE_URL = "http://localhost:8080/api/v1/artists";
+const BASE_URL = `${API_ROOT}/artists`;
 
 export const searchArtists = async (searchTerm: string) => {
   try {

--- a/Frontend/src/services/PlaylistService.tsx
+++ b/Frontend/src/services/PlaylistService.tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
+import { API_ROOT } from "./apiConfig";
 
-const BASE_URL = "https://api.frozenleafstudio.com/api/v1/playlists";
-//const BASE_URL = "http://localhost:8080/api/v1/playlists";
+const BASE_URL = `${API_ROOT}/playlists`;
 
 const searchPlaylists = async (show: string, artist: string) => {
   try {

--- a/Frontend/src/services/SetlistService.tsx
+++ b/Frontend/src/services/SetlistService.tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
+import { API_ROOT } from "./apiConfig";
 
-const BASE_URL = "https://api.frozenleafstudio.com/api/v1/setlists";
-//const BASE_URL = "http://localhost:8080/api/v1/setlists";
+const BASE_URL = `${API_ROOT}/setlists`;
 
 export const searchSetlists = async (mbid: string, pageNum: number) => {
   try {

--- a/Frontend/src/services/apiConfig.ts
+++ b/Frontend/src/services/apiConfig.ts
@@ -1,0 +1,5 @@
+// Root URL for all backend API calls.
+// Override locally via VITE_API_BASE_URL (see .env.development); falls back to
+// production so `npm run build` needs no configuration.
+export const API_ROOT =
+  import.meta.env.VITE_API_BASE_URL ?? "https://api.frozenleafstudio.com/api/v1";

--- a/Frontend/src/vite-env.d.ts
+++ b/Frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Removes the hardcoded-API-URL tech debt so local dev is 1:1 with no manual edits.

## Change
- New `src/services/apiConfig.ts` exports `API_ROOT` = `import.meta.env.VITE_API_BASE_URL ?? <prod>`.
- The three service files build their URL from `API_ROOT` instead of a hardcoded string + commented localhost line.
- Typed the env var in `vite-env.d.ts`.
- `Frontend/.env.development` (git-ignored) sets it to `localhost:8080` so `npm run dev` auto-targets a local backend; `npm run build` falls back to prod.

## Local workflow now
1. Start backend (ENV=local) · 2. `cd Frontend && npm run dev` -> :5173 talking to local :8080 · 3. no comment-flipping.

## Verified
`npm run build` + `npm run lint` pass; prod bundle embeds the prod URL with **no** localhost reference.