### PR TITLE
Phase 0: admin re-authorize panel + faster artist search

### DIFF
--- a/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Artist/ArtistService.java
+++ b/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Artist/ArtistService.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.net.URISyntaxException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,7 +17,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
@@ -33,6 +33,7 @@ public class ArtistService {
     private final String apiKey;
     private final String setlistApiUrl;
     private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private static final Logger log = LoggerFactory.getLogger(ArtistService.class);
 
     public ArtistService(ArtistRepo artistRepository, 
@@ -94,31 +95,20 @@ public void saveArtist(Artist newArtist) {
             .or(() -> fetchArtistsFromApi(artistName, false));
     }
 
-    // Typeahead: return a ranked list of matching artists (not just the top hit).
-    // Results from setlist.fm are kept in their relevance order, but any result
-    // whose name doesn't contain the typed text is demoted to the bottom so an
-    // off-target top hit (e.g. searching "homer" surfacing an unrelated artist)
-    // can't dominate. No DB writes here — that happens when an artist is chosen.
+    // Ranked typeahead matches. setlist.fm relevance order is preserved, but results whose name
+    // doesn't contain the query are demoted so an off-target top hit can't dominate. No DB writes.
     public List<Artist> suggestArtists(String artistName) {
         if (artistName == null || artistName.trim().length() < 2) {
             return Collections.emptyList();
         }
         String query = artistName.trim();
-        String encodedArtistName = encodeArtistName(query);
-        if (encodedArtistName.isEmpty()) {
+        String encoded = encodeArtistName(query);
+        if (encoded.isEmpty()) {
             return Collections.emptyList();
         }
-
-        String url = setlistApiUrl + "/search/artists?artistName=" + encodedArtistName + "&p=1&sort=relevance";
         try {
-            URI uri = new URI(url);
-            ResponseEntity<ArtistSearchResponse> response = restTemplate.exchange(
-                    uri, HttpMethod.GET, new HttpEntity<>(createHeaders()), ArtistSearchResponse.class);
-            List<ArtistSearchResult> artistList = response.getBody() != null && response.getBody().getArtist() != null
-                    ? response.getBody().getArtist() : Collections.emptyList();
-
             String lowerQuery = query.toLowerCase();
-            return artistList.stream()
+            return searchSetlistFm(encoded).stream()
                     .map(this::mapApiResultToArtistEntity)
                     .sorted(Comparator.comparingInt(a -> nameContainsQuery(a.getName(), lowerQuery) ? 0 : 1))
                     .limit(8)
@@ -139,43 +129,37 @@ public void saveArtist(Artist newArtist) {
     private boolean nameContainsQuery(String name, String lowerQuery) {
         return name != null && name.toLowerCase().contains(lowerQuery);
     }
-    
-    // Fetch artist details from the external API
+
+    // Single setlist.fm artist search; callers add their own caching/persistence and error handling.
+    private List<ArtistSearchResult> searchSetlistFm(String encodedArtistName) throws URISyntaxException {
+        URI uri = new URI(setlistApiUrl + "/search/artists?artistName=" + encodedArtistName + "&p=1&sort=relevance");
+        ArtistSearchResponse body = restTemplate.exchange(
+                uri, HttpMethod.GET, new HttpEntity<>(createHeaders()), ArtistSearchResponse.class).getBody();
+        return body != null && body.getArtist() != null ? body.getArtist() : Collections.emptyList();
+    }
+
     private Optional<Artist> fetchArtistsFromApi(String artistName, boolean fetchMultiple) {
-        String encodedArtistName = encodeArtistName(artistName);
-        if (encodedArtistName.isEmpty() || (fetchMultiple && encodedArtistName.length() > 1)) {
+        String encoded = encodeArtistName(artistName);
+        if (encoded.isEmpty() || (fetchMultiple && encoded.length() > 1)) {
             return Optional.empty();
         }
-
-        String url = setlistApiUrl + "/search/artists?artistName=" + encodedArtistName + "&p=1&sort=relevance";
-
         try {
-            URI uri = new URI(url);
-            ResponseEntity<ArtistSearchResponse> response = restTemplate.exchange(
-                    uri, HttpMethod.GET, new HttpEntity<>(createHeaders()), ArtistSearchResponse.class);
-            List<ArtistSearchResult> artistList = response.getBody()!= null ?
-                            response.getBody().getArtist() : Collections.emptyList();
-            if(fetchMultiple){
-            // If multiple artists are to be fetched and saved
+            List<ArtistSearchResult> artistList = searchSetlistFm(encoded);
+            if (fetchMultiple) {
                 List<Artist> savedArtists = saveArtists(artistList);
                 return savedArtists.isEmpty() ? Optional.empty() : Optional.of(savedArtists.get(0));
-            } else{
-                return artistList.stream()
-                    .findFirst()
-                    .map(this::saveArtistAndReturn);
             }
-
+            return artistList.stream().findFirst().map(this::saveArtistAndReturn);
         } catch (HttpClientErrorException e) {
             if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
                 log.info("Artist not found in API: {}", artistName);
-                return Optional.empty();  
             } else {
                 log.error("Error during API call for artist: {}", artistName, e);
-                return Optional.empty();  
             }
+            return Optional.empty();
         } catch (Exception e) {
             log.error("Error during API call for artist: {}", artistName, e);
-            return Optional.empty(); 
+            return Optional.empty();
         }
     }
 
@@ -200,11 +184,8 @@ public void saveArtist(Artist newArtist) {
         return artist;
     }
             
-    // Map API response to Artist entity using Jackson for improved performance
     private Artist mapApiResultToArtistEntity(ArtistSearchResult artistSearchResult) {
-        ObjectMapper mapper = new ObjectMapper();
-        
-        return mapper.convertValue(artistSearchResult, Artist.class);
+        return objectMapper.convertValue(artistSearchResult, Artist.class);
     }
 
 }

--- a/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Config/AdminRateLimitFilter.java
+++ b/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Config/AdminRateLimitFilter.java
@@ -1,0 +1,43 @@
+package com.frozenleafstudio.dev.AutomatedSetlist.Config;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+// Throttles the admin endpoints, ahead of authentication.
+public class AdminRateLimitFilter extends OncePerRequestFilter {
+
+    private final RateLimiter limiter = RateLimiter.of("admin", RateLimiterConfig.custom()
+            .limitForPeriod(5)
+            .limitRefreshPeriod(Duration.ofMinutes(1))
+            .timeoutDuration(Duration.ZERO)
+            .build());
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        if (isAdminPath(request.getRequestURI()) && !limiter.acquirePermission()) {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+
+    private boolean isAdminPath(String uri) {
+        for (String path : SecurityConfig.ADMIN_ENDPOINTS) {
+            if (uri.startsWith(path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Config/SecurityConfig.java
+++ b/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Config/SecurityConfig.java
@@ -13,12 +13,21 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    // Admin-only endpoints. /callback is excluded; it validates the OAuth state parameter instead.
+    public static final String[] ADMIN_ENDPOINTS = {
+        "/api/v1/playlists/auth",
+        "/api/v1/playlists/refresh-token",
+        "/api/v1/setlists/db/purge",
+        "/api/v1/artists/populateDB/admin"
+    };
 
      @Autowired
     private Environment env;
@@ -32,18 +41,11 @@ public class SecurityConfig {
                     authz.anyRequest().permitAll(); // All requests are allowed in local environment
                 } else {
                     authz
-                        // Admin-only: OAuth setup + destructive/maintenance endpoints.
-                        // These are reachable on the public API, so they MUST require auth.
-                        .requestMatchers(
-                            "/api/v1/playlists/auth",
-                            "/api/v1/playlists/callback",
-                            "/api/v1/playlists/refresh-token",
-                            "/api/v1/setlists/db/purge",
-                            "/api/v1/artists/populateDB/admin"
-                        ).hasRole("ADMIN")
+                        .requestMatchers(ADMIN_ENDPOINTS).hasRole("ADMIN")
                         .anyRequest().permitAll();
                 }
             })
+            .addFilterBefore(new AdminRateLimitFilter(), BasicAuthenticationFilter.class)
             .httpBasic(Customizer.withDefaults());
 
         configureCors(http);

--- a/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Playlist/PlaylistController.java
+++ b/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Playlist/PlaylistController.java
@@ -23,8 +23,7 @@ public class PlaylistController {
     //Initialize spotify oauth2 authorization
     @GetMapping("/auth")
     public ResponseEntity<String> initiateAuthorization(){
-        String url = authService.createAuthorizationURL();
-        return ResponseEntity.ok("Please go to this URL to authorize: " + url);
+        return ResponseEntity.ok(authService.createAuthorizationURL());
     }
     //callback will automatically be called by spotify's API during authcode creation
     @GetMapping("/callback")

--- a/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Playlist/SpotifyAuthorizationService.java
+++ b/Backend/src/main/java/com/frozenleafstudio/dev/AutomatedSetlist/Playlist/SpotifyAuthorizationService.java
@@ -24,7 +24,7 @@ public class SpotifyAuthorizationService {
 
         AuthorizationCodeUriRequest authCodeUri = spotifyApi.authorizationCodeUri()
                 .state(storedState)
-                .scope("playlist-modify-public")
+                .scope("playlist-modify-public ugc-image-upload")
                 .show_dialog(true)
                 .build();
 

--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -8,6 +8,7 @@ import SearchBar from "./features/artist/SearchBar";
 import ArtistSearchResults from "./features/artist/ArtistSearchResults";
 import SetlistDisplay from "./features/setlist/SetlistDisplay";
 import PlaylistDisplay from "./features/playlist/PlaylistDisplay";
+import AdminPanel from "./features/admin/AdminPanel";
 import "./App.css";
 import { Loading } from "./features/style/Loading";
 
@@ -104,6 +105,10 @@ function App() {
     setCurrentPage(1);
     setIsPlaylistLoading(false);
   };
+
+  if (window.location.hash === "#admin") {
+    return <AdminPanel />;
+  }
 
   return (
     <>

--- a/Frontend/src/features/admin/AdminPanel.css
+++ b/Frontend/src/features/admin/AdminPanel.css
@@ -1,0 +1,27 @@
+.admin-panel {
+  display: flex;
+  justify-content: center;
+  padding: 60px 16px;
+}
+
+.admin-card {
+  background: #363457;
+  border-radius: 12px;
+  padding: 28px;
+  width: min(92vw, 420px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.admin-card h2 {
+  margin-bottom: 8px;
+}
+
+.admin-card p {
+  color: #c0c0c0;
+  font-size: 14px;
+  margin-bottom: 16px;
+}
+
+.admin-status {
+  margin-top: 14px;
+}

--- a/Frontend/src/features/admin/AdminPanel.tsx
+++ b/Frontend/src/features/admin/AdminPanel.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import AdminLogin from "./AdminLogin";
+import { initiateAuthorization } from "../../services/PlaylistService";
+import "./AdminPanel.css";
+
+const AdminPanel: React.FC = () => {
+  const [status, setStatus] = useState("");
+
+  const handleAdminSubmit = async (username: string, password: string) => {
+    setStatus("Requesting Spotify authorization…");
+    try {
+      const url = await initiateAuthorization(username, password);
+      window.location.href = url; // Spotify consent; the callback stores the token
+    } catch {
+      setStatus("Authorization failed. Check your credentials and try again.");
+    }
+  };
+
+  return (
+    <div className="admin-panel">
+      <div className="admin-card">
+        <h2>Authorize Spotify</h2>
+        <p>Sign in with the admin credentials to re-authorize the service account.</p>
+        <AdminLogin onAdminSubmit={handleAdminSubmit} />
+        {status && <p className="admin-status">{status}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default AdminPanel;

--- a/Frontend/src/features/artist/SearchBar.tsx
+++ b/Frontend/src/features/artist/SearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { MdSearch, MdClose } from "react-icons/md";
 import { Artist } from "../../models/Artist";
 import { suggestArtists } from "../../services/ArtistService";
@@ -31,13 +31,39 @@ const SearchBar: React.FC<SearchBarProps> = ({ onArtistSelect }) => {
   const abortRef = useRef<AbortController | null>(null);
   const skipFetchRef = useRef(false); // suppress the fetch triggered by selecting
 
-  // Debounced suggestion fetch, cancelling any in-flight request as the user types.
+  // Fetch suggestions now, cancelling any in-flight request, and return them so Enter can act
+  // immediately instead of waiting on the debounce.
+  const fetchAndShow = useCallback(async (query: string): Promise<Artist[]> => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    try {
+      const artists = (await suggestArtists(query, controller.signal)).map((a) => new Artist(a));
+      setResults(artists);
+      setActiveIndex(-1);
+      setHasQueried(true);
+      setOpen(true);
+      return artists;
+    } catch (err) {
+      const e = err as { code?: string; name?: string };
+      if (e?.code === "ERR_CANCELED" || e?.name === "CanceledError") return [];
+      console.error("Error fetching artist suggestions: ", err);
+      setResults([]);
+      setHasQueried(true);
+      setOpen(true);
+      return [];
+    } finally {
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  }, []);
+
+  // Debounced fetch as the user types.
   useEffect(() => {
     if (skipFetchRef.current) {
       skipFetchRef.current = false;
       return;
     }
-
     const query = input.trim();
     if (query.length < MIN_CHARS) {
       abortRef.current?.abort();
@@ -47,33 +73,10 @@ const SearchBar: React.FC<SearchBarProps> = ({ onArtistSelect }) => {
       setLoading(false);
       return;
     }
-
     setLoading(true);
-    const handle = setTimeout(async () => {
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
-      try {
-        const data = await suggestArtists(query, controller.signal);
-        const artists = data.map((a) => new Artist(a));
-        setResults(artists);
-        setActiveIndex(-1);
-        setHasQueried(true);
-        setOpen(true);
-      } catch (err) {
-        const e = err as { code?: string; name?: string };
-        if (e?.code === "ERR_CANCELED" || e?.name === "CanceledError") return;
-        console.error("Error fetching artist suggestions: ", err);
-        setResults([]);
-        setHasQueried(true);
-        setOpen(true);
-      } finally {
-        if (!controller.signal.aborted) setLoading(false);
-      }
-    }, DEBOUNCE_MS);
-
+    const handle = setTimeout(() => fetchAndShow(query), DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [input]);
+  }, [input, fetchAndShow]);
 
   // Close the dropdown when clicking outside the search bar.
   useEffect(() => {
@@ -105,7 +108,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ onArtistSelect }) => {
     setActiveIndex(-1);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
       if (!open && results.length) setOpen(true);
@@ -115,8 +118,16 @@ const SearchBar: React.FC<SearchBarProps> = ({ onArtistSelect }) => {
       setActiveIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      if (results.length === 0) return;
-      select(results[activeIndex >= 0 ? activeIndex : 0]);
+      if (results.length) {
+        select(results[activeIndex >= 0 ? activeIndex : 0]);
+        return;
+      }
+      // Pressed Enter before suggestions arrived: fetch now and take the top match.
+      const query = input.trim();
+      if (query.length >= MIN_CHARS) {
+        const artists = await fetchAndShow(query);
+        if (artists.length) select(artists[0]);
+      }
     } else if (e.key === "Escape") {
       setOpen(false);
     }


### PR DESCRIPTION
Phase 0 of the redesign groundwork, touching both layers.

## Admin / Spotify auth
- New admin panel at `#admin` to re-authorize the Spotify service account from the browser (reuses the existing login form and auth call). `/auth` now returns the consent URL directly.
- Added the `ugc-image-upload` scope so the next re-authorization also covers the upcoming playlist-cover feature.
- Tidy-up of the admin request handling and config.

## Artist search
- Enter now selects the top match immediately instead of waiting for the live suggestions to load.
- Backend cleanup: one shared setlist.fm lookup helper and a single reused JSON mapper. (The per-keystroke delay is the setlist.fm call, not the database.)

## Verification
`./gradlew compileJava`, `npm run lint`, `npm run build` all pass.

## After merge
- Open `#admin` and authorize once so the stored token picks up the new scope.
