### PR TITLE
Phase 1: mobile layout + playlist success screen

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.9",
         "mini.css": "^3.0.1",
         "mousetrap": "^1.6.5",
+        "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-datepicker": "^4.24.0",
         "react-dom": "^18.2.0",
@@ -3180,6 +3181,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.7.9",
     "mini.css": "^3.0.1",
     "mousetrap": "^1.6.5",
+    "qrcode.react": "^4.2.0",
     "react": "^18.2.0",
     "react-datepicker": "^4.24.0",
     "react-dom": "^18.2.0",

--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -40,22 +40,21 @@
 .setlist-playlist-container {
   display: flex;
   flex-direction: row;
+  gap: 16px;
   width: 100%;
   height: 100%;
 }
 
-.setlist-display {
-  flex: 0 0 30%;
-  height: auto;
-}
-
 .playlist-display {
-  flex: 0 0 70%;
-  display: flex;
+  flex: 1;
+  min-width: 0;
   height: auto;
 }
 
-/* Media Queries */
+.sheet-scrim {
+  display: none;
+}
+
 @media (max-width: 1024px) {
   .main-container,
   .artist-name-container {
@@ -67,57 +66,51 @@
     padding: 10px;
     min-width: 0;
   }
-
-  .setlist-display,
-  .playlist-display {
-    flex: 0 0 auto;
-  }
-
-  .setlist-display {
-    flex: 0 0 30%; /* 30% of the container */
-  }
-
-  .playlist-display {
-    flex: 0 0 70%; /* 70% of the container */
-  }
 }
 
+/* Phones: list goes full-width single column; the detail opens as a bottom sheet. */
 @media (max-width: 768px) {
   .main-container {
     width: 100%;
-    min-width: 0; /* clear the 400px desktop min so it can't overflow a phone */
+    min-width: 0;
     height: 100vh;
     height: 100dvh;
     margin-top: 10px;
   }
 
   .main-content {
-    margin: 0; 
-    padding: 0; 
+    margin: 0;
+    padding: 8px;
+    min-width: 0;
+    border-radius: 10px;
   }
 
   .setlist-playlist-container {
     flex-direction: column;
   }
 
-  .setlist-display,
+  .sheet-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 40;
+  }
+
   .playlist-display {
-    width: 100%; 
-    min-height: 50vh;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 50;
+    max-height: 88dvh;
+    margin: 0;
+    border-radius: 18px 18px 0 0;
+    animation: sheet-up 0.28s ease;
   }
 }
 
-@media (max-width: 600px) {
-  .main-content {
-    padding: 0;
-    margin: 0;
-    border-radius: 10px; 
-  }
-
-  .setlist-display,
-  .playlist-display {
-    flex-direction: column;
-    padding: 0;
-    margin: 0;
-  }
+@keyframes sheet-up {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
 }

--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -96,6 +96,12 @@ function App() {
       console.error("Unable to search for Artist: ", error);
     }
   };
+  const handleCloseDetail = () => {
+    setSelectedSetlist(null);
+    setPlaylist(null);
+    setPlaylistExist(false);
+  };
+
   const resetStates = () => {
     setSetlists([]);
     setSetlistsExist(false);
@@ -138,12 +144,16 @@ function App() {
                   <Loading />
                 ) : (
                   selectedSetlist && (
-                    <PlaylistDisplay
-                      spotifyPlaylist={playlist}
-                      setlist={selectedSetlist}
-                      createSpotifyPlaylist={PlayistCreation}
-                      className={playlistExist ? "active" : ""}
-                    />
+                    <>
+                      <div className="sheet-scrim" onClick={handleCloseDetail} />
+                      <PlaylistDisplay
+                        spotifyPlaylist={playlist}
+                        setlist={selectedSetlist}
+                        createSpotifyPlaylist={PlayistCreation}
+                        onClose={handleCloseDetail}
+                        className={playlistExist ? "active" : ""}
+                      />
+                    </>
                   )
                 )}
               </div>

--- a/Frontend/src/features/playlist/PlaylistDetails.tsx
+++ b/Frontend/src/features/playlist/PlaylistDetails.tsx
@@ -4,14 +4,12 @@ import "./PlaylistDetails.css";
 type PlaylistDetailsProps = {
   name: string;
   description: string;
-  spotifyURL: string;
   albumImages: string[];
 };
 
 export const PlaylistDetails: React.FC<PlaylistDetailsProps> = ({
   name,
   description,
-  spotifyURL,
   albumImages,
 }) => {
   return (
@@ -28,11 +26,6 @@ export const PlaylistDetails: React.FC<PlaylistDetailsProps> = ({
       </div>
       <h3 className="playlist-title">{name}</h3>
       <p className="playlist-description">{description}</p>
-      {spotifyURL && (
-        <a href={spotifyURL} target="_blank">
-          Open Spotify Playlist
-        </a>
-      )}
     </div>
   );
 };

--- a/Frontend/src/features/playlist/PlaylistDisplay.css
+++ b/Frontend/src/features/playlist/PlaylistDisplay.css
@@ -42,6 +42,18 @@
   }
 }
 
+.playlist-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 40px 20px;
+  text-align: center;
+  color: #ffffff;
+}
+
 .sheet-handle {
   display: none;
 }

--- a/Frontend/src/features/playlist/PlaylistDisplay.css
+++ b/Frontend/src/features/playlist/PlaylistDisplay.css
@@ -41,3 +41,20 @@
     padding: 8px 0;
   }
 }
+
+.sheet-handle {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .sheet-handle {
+    display: block;
+    flex: 0 0 auto;
+    width: 44px;
+    height: 5px;
+    margin: 0 auto 12px;
+    border-radius: 3px;
+    background: #c0c0c0;
+    cursor: pointer;
+  }
+}

--- a/Frontend/src/features/playlist/PlaylistDisplay.tsx
+++ b/Frontend/src/features/playlist/PlaylistDisplay.tsx
@@ -14,6 +14,7 @@ type PlaylistResultsProps = {
     includeCovers: boolean
   ) => Promise<void>;
   setlist: Setlist | null;
+  onClose?: () => void;
   className?: string;
 };
 const formatSetlistForModal = (setlist: Setlist) => {
@@ -34,6 +35,7 @@ const PlaylistDisplay: React.FC<PlaylistResultsProps> = ({
   spotifyPlaylist,
   createSpotifyPlaylist,
   setlist,
+  onClose,
   className,
 }) => {
   const [includeCovers, setIncludeCovers] = useState(true);
@@ -61,6 +63,7 @@ const PlaylistDisplay: React.FC<PlaylistResultsProps> = ({
 
   return (
     <div className={`playlist-display ${className}`}>
+      {onClose && <div className="sheet-handle" onClick={onClose} />}
       <div className="playlist-info-card">
         <PlaylistDetails
           name={spotifyPlaylist.name}

--- a/Frontend/src/features/playlist/PlaylistDisplay.tsx
+++ b/Frontend/src/features/playlist/PlaylistDisplay.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import { Playlist } from "../../models/Playlist";
 import { Setlist } from "../../models/Setlist";
-import { PlaylistItems } from "./PlaylistItems"; // Adjust the path as necessary
-import { PlaylistDetails } from "./PlaylistDetails"; // Adjust the path as necessary
-import { Modal } from "./Modal"; // Adjust the path as necessary
-import { PlaylistActions } from "./PlaylistActions"; // Adjust the path as necessary
+import { PlaylistItems } from "./PlaylistItems";
+import { PlaylistDetails } from "./PlaylistDetails";
+import { PlaylistSuccess } from "./PlaylistSuccess";
+import { Modal } from "./Modal";
+import { PlaylistActions } from "./PlaylistActions";
 import "./PlaylistDisplay.css";
 
 type PlaylistResultsProps = {
@@ -60,31 +61,60 @@ const PlaylistDisplay: React.FC<PlaylistResultsProps> = ({
   };
 
   const albumImages = getAlbumImagesForMosaic();
+  const foundCount = spotifyPlaylist.tracks.filter((t) => t.trackFound).length;
+
+  let body;
+  if (foundCount === 0) {
+    body = (
+      <div className="playlist-empty">
+        <p>No tracks from this setlist could be matched on Spotify.</p>
+        {setlist && (
+          <a href={setlist.url} target="_blank" rel="noopener noreferrer">
+            View this setlist on setlist.fm
+          </a>
+        )}
+      </div>
+    );
+  } else if (spotifyPlaylist.spotifyUrl) {
+    body = (
+      <PlaylistSuccess
+        name={spotifyPlaylist.name}
+        spotifyUrl={spotifyPlaylist.spotifyUrl}
+        trackCount={foundCount}
+        coverImages={albumImages}
+        onBuildAnother={onClose}
+      />
+    );
+  } else {
+    body = (
+      <>
+        <div className="playlist-info-card">
+          <PlaylistDetails
+            name={spotifyPlaylist.name}
+            description={spotifyPlaylist.description}
+            albumImages={albumImages}
+          />
+          <PlaylistActions
+            onPlaylistCreation={handlePlaylistCreation}
+            setIncludeCovers={setIncludeCovers}
+            includeCovers={includeCovers}
+          />
+        </div>
+        <div className="playlist-items">
+          <PlaylistItems
+            tracks={spotifyPlaylist.tracks}
+            includeCovers={includeCovers}
+            onOpenModal={() => setIsModalOpen(true)}
+          />
+        </div>
+      </>
+    );
+  }
 
   return (
     <div className={`playlist-display ${className}`}>
       {onClose && <div className="sheet-handle" onClick={onClose} />}
-      <div className="playlist-info-card">
-        <PlaylistDetails
-          name={spotifyPlaylist.name}
-          description={spotifyPlaylist.description}
-          spotifyURL={spotifyPlaylist ? spotifyPlaylist.spotifyUrl : ""}
-          albumImages={albumImages}
-        />
-
-        <PlaylistActions
-          onPlaylistCreation={handlePlaylistCreation}
-          setIncludeCovers={setIncludeCovers}
-          includeCovers={includeCovers}
-        />
-      </div>
-      <div className="playlist-items">
-        <PlaylistItems
-          tracks={spotifyPlaylist.tracks}
-          includeCovers={includeCovers}
-          onOpenModal={() => setIsModalOpen(true)}
-        />
-      </div>
+      {body}
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
         {setlist && formatSetlistForModal(setlist)}
       </Modal>

--- a/Frontend/src/features/playlist/PlaylistSuccess.css
+++ b/Frontend/src/features/playlist/PlaylistSuccess.css
@@ -1,0 +1,124 @@
+.playlist-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  width: 100%;
+  padding: 16px;
+  color: #ffffff;
+}
+
+.success-badge {
+  display: flex;
+  font-size: 48px;
+  color: #00a693;
+  margin-bottom: 8px;
+}
+
+.success-subtitle {
+  color: #c0c0c0;
+  font-size: 14px;
+  margin-bottom: 18px;
+}
+
+.success-cover {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  width: 140px;
+  height: 140px;
+  border-radius: 10px;
+  overflow: hidden;
+  margin-bottom: 16px;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.3);
+}
+
+.success-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.success-name {
+  font-size: 18px;
+  line-height: 1.3;
+  margin-bottom: 4px;
+}
+
+.success-count {
+  color: #c0c0c0;
+  font-size: 13px;
+  margin-bottom: 18px;
+}
+
+.open-spotify {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background-color: #1db954;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: bold;
+  padding: 14px 28px;
+  border-radius: 28px;
+  margin-bottom: 14px;
+}
+
+.open-spotify:hover {
+  background-color: #1aa34a;
+  color: #ffffff;
+}
+
+.success-secondary {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 22px;
+}
+
+.success-secondary button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background-color: #2c2a47;
+  color: #ffffff;
+  border: 1px solid #4d4a70;
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.success-qr {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.success-qr > :first-child {
+  background: #ffffff;
+  padding: 10px;
+  border-radius: 12px;
+}
+
+.success-qr span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+  justify-content: center;
+  color: #c0c0c0;
+  font-size: 12px;
+  max-width: 240px;
+}
+
+.build-another {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  color: #00a693;
+  border: none;
+  font-size: 14px;
+  cursor: pointer;
+}

--- a/Frontend/src/features/playlist/PlaylistSuccess.tsx
+++ b/Frontend/src/features/playlist/PlaylistSuccess.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from "react";
+import { FaSpotify } from "react-icons/fa";
+import {
+  MdCheckCircle,
+  MdLink,
+  MdOutlineShare,
+  MdFavoriteBorder,
+  MdArrowBack,
+} from "react-icons/md";
+import { QRCodeSVG } from "qrcode.react";
+import "./PlaylistSuccess.css";
+
+type PlaylistSuccessProps = {
+  name: string;
+  spotifyUrl: string;
+  trackCount: number;
+  coverImages: string[];
+  onBuildAnother?: () => void;
+};
+
+export const PlaylistSuccess: React.FC<PlaylistSuccessProps> = ({
+  name,
+  spotifyUrl,
+  trackCount,
+  coverImages,
+  onBuildAnother,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(spotifyUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
+
+  const share = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: name, url: spotifyUrl });
+      } catch {
+        /* dismissed */
+      }
+    } else {
+      copyLink();
+    }
+  };
+
+  return (
+    <div className="playlist-success">
+      <div className="success-badge">
+        <MdCheckCircle />
+      </div>
+      <p className="success-subtitle">Your playlist is live on Spotify</p>
+
+      {coverImages.length > 0 && (
+        <div className="success-cover">
+          {coverImages.map((url, i) => (
+            <img key={i} src={url} alt="" />
+          ))}
+        </div>
+      )}
+
+      <h3 className="success-name">{name}</h3>
+      <p className="success-count">{trackCount} tracks</p>
+
+      <a
+        className="open-spotify"
+        href={spotifyUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FaSpotify /> Open in Spotify
+      </a>
+
+      <div className="success-secondary">
+        <button onClick={copyLink}>
+          <MdLink /> {copied ? "Copied" : "Copy link"}
+        </button>
+        <button onClick={share}>
+          <MdOutlineShare /> Share
+        </button>
+      </div>
+
+      <div className="success-qr">
+        <QRCodeSVG value={spotifyUrl} size={128} bgColor="#ffffff" />
+        <span>
+          Scan to open it on your phone, then tap <MdFavoriteBorder /> Save.
+        </span>
+      </div>
+
+      {onBuildAnother && (
+        <button className="build-another" onClick={onBuildAnother}>
+          <MdArrowBack /> Build another playlist
+        </button>
+      )}
+    </div>
+  );
+};

--- a/Frontend/src/features/setlist/setlist.css
+++ b/Frontend/src/features/setlist/setlist.css
@@ -1,10 +1,3 @@
-.setlist-playlist-container {
-  display: flex;
-  flex-direction: row;
-  height: 100%;
-  width: 100%;
-}
-
 .setlist-container {
   flex-grow: 1;
   display: flex;
@@ -104,7 +97,12 @@
   .setlist-date {
     justify-content: center;
   }
+}
 
-  .selectArrow {
+@media (max-width: 768px) {
+  .setlist-container,
+  .setlist-container.active {
+    width: 100%;
+    margin-right: 0;
   }
 }

--- a/Frontend/src/features/setlist/setlist.css
+++ b/Frontend/src/features/setlist/setlist.css
@@ -7,12 +7,11 @@
 }
 
 .setlist-container.active {
-  width: 30%;
-  flex-grow: 1;
+  flex: 0 0 32%;
   display: flex;
   flex-direction: column;
   margin-right: 10px;
-  transition: width 0.3s ease, margin-right 0.3s ease;
+  transition: flex-basis 0.3s ease, margin-right 0.3s ease;
 }
 .setlist-scroll-wrapper {
   overflow-x: hidden;
@@ -102,6 +101,7 @@
 @media (max-width: 768px) {
   .setlist-container,
   .setlist-container.active {
+    flex: 0 0 auto;
     width: 100%;
     margin-right: 0;
   }


### PR DESCRIPTION
Phase 1 of the redesign: mobile layout + the playlist success screen. The cover picker is split into a follow-up PR, since it depends on a one-time Spotify re-authorization.

## Mobile layout
- Phones now drop to a single full-width column, fixing the duplicated `.setlist-playlist-container` rule that kept the desktop split on mobile and crammed setlist cards into a narrow column.
- Selecting a show opens the detail as a bottom sheet (scrim + drag handle). Desktop keeps the two-column layout, now with a narrow list and a wide detail panel.

## Success screen
- Replaces the bare "Open Spotify Playlist" link with a result view: confirmation badge, cover, name and track count, Open in Spotify, copy link / share, a scannable QR, and a "build another" action.
- Adds a "no tracks matched" empty state for setlists with nothing on Spotify.

## Verification
`npm run lint` (--max-warnings 0) and `npm run build` pass. Verified visually at mobile and desktop widths against live data.

## Follow-up (separate PR)
- Cover picker (choose an album cover or upload your own), which needs the `ugc-image-upload` re-auth.
